### PR TITLE
Add React to imports for example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@
 <code>npm i @bayer/ol-kit ol@4.6.5 react react-dom styled-components --save</code>
 <h2>Getting Started</h2>
 <p>It's easy to start building map apps with ol-kit. For simple projects the following will get you started:</p>
-<pre class="prettyprint source lang-javascript"><code>import { Component } from 'react'
+<pre class="prettyprint source lang-javascript"><code>import React, { Component } from 'react'
 import { Map, Controls, zoomToExtent } from '@bayer/ol-kit'
 
 import VectorLayer from 'ol/layer/Vector'


### PR DESCRIPTION
Importing of `React` was missing from the example docs, preventing a clean start from copy and paste.